### PR TITLE
fix: mitigate supply chain attacks via CI and Renovate hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
   lint:
     runs-on: ubuntu-latest
     needs: prepare

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "group:allNonMajor"],
+  "minimumReleaseAge": "7 days",
   "timezone": "Asia/Tokyo",
   "assignees": ["tokku5552"],
   "prConcurrentLimit": 5,


### PR DESCRIPTION
## Summary
- CIの `yarn install` に `--ignore-scripts` フラグを追加し、postinstallフック経由のマルウェア実行を防止
- Renovateに `minimumReleaseAge: "7 days"` を設定し、公開直後の危険なパッケージの即時採用を抑制

## Background
2026/3/30 の axios 1.14.1 サプライチェーン攻撃を受けたロングターム対策です。

## Test plan
- [ ] CI ワークフローが正常に動作すること（yarn install --ignore-scripts で依存関係がインストールされること）
- [ ] Renovate が minimumReleaseAge を認識し、公開から7日未満のパッケージに対してPRを作成しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)