### PR TITLE
fix(article): sort articles by publishedAt in descending order (TOK-95)

### DIFF
--- a/src/features/article/apis/article.spec.ts
+++ b/src/features/article/apis/article.spec.ts
@@ -1,0 +1,106 @@
+import { Article } from '../types/article';
+
+jest.mock('./zenn', () => ({
+  fetchArticlesFromZenn: jest.fn(),
+}));
+jest.mock('./qiita', () => ({
+  fetchArticlesFromQiita: jest.fn(),
+}));
+jest.mock('../data/static-data', () => ({
+  staticArticlesData: [] as Article[],
+}));
+
+import { fetchArticles } from './article';
+import { fetchArticlesFromQiita } from './qiita';
+import { fetchArticlesFromZenn } from './zenn';
+import { staticArticlesData } from '../data/static-data';
+
+const mockedZenn = fetchArticlesFromZenn as jest.MockedFunction<
+  typeof fetchArticlesFromZenn
+>;
+const mockedQiita = fetchArticlesFromQiita as jest.MockedFunction<
+  typeof fetchArticlesFromQiita
+>;
+
+const buildArticle = (
+  overrides: Partial<Article> & Pick<Article, 'title' | 'publishedAt'>
+): Article => ({
+  bodySummary: '',
+  source: 'zenn',
+  url: `https://example.com/${overrides.title}`,
+  imageUrl: '',
+  ...overrides,
+});
+
+describe('fetchArticles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (staticArticlesData as Article[]).length = 0;
+  });
+
+  test('publishedAt の降順で記事をソートする（複数ソース統合）', async () => {
+    mockedZenn.mockResolvedValue([
+      buildArticle({
+        title: 'zenn-old',
+        source: 'zenn',
+        publishedAt: '2024-01-10T00:00:00.000Z',
+      }),
+      buildArticle({
+        title: 'zenn-new',
+        source: 'zenn',
+        publishedAt: '2025-03-01T00:00:00.000Z',
+      }),
+    ]);
+    mockedQiita.mockResolvedValue([
+      buildArticle({
+        title: 'qiita-mid',
+        source: 'qiita',
+        publishedAt: '2024-08-15T00:00:00.000Z',
+      }),
+    ]);
+    (staticArticlesData as Article[]).push(
+      buildArticle({
+        title: 'blog-newest',
+        source: 'blog',
+        publishedAt: '2026-04-01T00:00:00.000Z',
+      }),
+      buildArticle({
+        title: 'blog-oldest',
+        source: 'blog',
+        publishedAt: '2023-05-20T00:00:00.000Z',
+      })
+    );
+
+    const result = await fetchArticles();
+
+    expect(result.map((a) => a.title)).toEqual([
+      'blog-newest',
+      'zenn-new',
+      'qiita-mid',
+      'zenn-old',
+      'blog-oldest',
+    ]);
+  });
+
+  test('num 引数で先頭 N 件のみを返す', async () => {
+    mockedZenn.mockResolvedValue([
+      buildArticle({
+        title: 'a',
+        publishedAt: '2025-01-01T00:00:00.000Z',
+      }),
+      buildArticle({
+        title: 'b',
+        publishedAt: '2024-01-01T00:00:00.000Z',
+      }),
+      buildArticle({
+        title: 'c',
+        publishedAt: '2023-01-01T00:00:00.000Z',
+      }),
+    ]);
+    mockedQiita.mockResolvedValue([]);
+
+    const result = await fetchArticles(2);
+
+    expect(result.map((a) => a.title)).toEqual(['a', 'b']);
+  });
+});

--- a/src/features/article/apis/article.ts
+++ b/src/features/article/apis/article.ts
@@ -8,10 +8,10 @@ export const fetchArticles = async (num?: number) => {
   const staticArticles = staticArticlesData;
 
   const articles = [...zennArticles, ...qiitaArticles, ...staticArticles];
-  // publishedAt で降順に並び替え
-  const sortedArticles = articles.sort((a, b) => {
-    return b.publishedAt < a.publishedAt ? -1 : 1;
-  });
+  const sortedArticles = articles.sort(
+    (a, b) =>
+      new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+  );
 
   return num ? sortedArticles.slice(0, num) : sortedArticles;
 };

--- a/src/features/article/apis/qiita.ts
+++ b/src/features/article/apis/qiita.ts
@@ -123,7 +123,7 @@ const toArticleFromQiita = (
     bodySummary: truncateText(stripHtmlTags(qiitaArticle.renderedBody), 100),
     source: 'qiita',
     url: qiitaArticle.url,
-    publishedAt: qiitaArticle.createdAt,
+    publishedAt: new Date(qiitaArticle.createdAt).toISOString(),
     imageUrl: imageUrl,
   };
 };

--- a/src/features/article/apis/zenn.ts
+++ b/src/features/article/apis/zenn.ts
@@ -104,7 +104,7 @@ const toArticleFromZenn = (
     bodySummary: bodySummary,
     source: 'zenn',
     url: `https://zenn.dev/${zennArticle.user.username}/articles/${zennArticle.slug}`,
-    publishedAt: zennArticle.publishedAt,
+    publishedAt: new Date(zennArticle.publishedAt).toISOString(),
     imageUrl: imageUrl,
   };
 };

--- a/src/features/article/data/static-data.ts
+++ b/src/features/article/data/static-data.ts
@@ -8,7 +8,7 @@ export const staticArticlesData: Article[] = [
       'こんにちは。サイバーエージェント AI事業本部の徳田です。 先日2024年1月25日に開催されたAWS cafeteria #1の様子についてご紹介いたします。',
     source: 'blog',
     url: 'https://developers.cyberagent.co.jp/blog/archives/46221/',
-    publishedAt: `${new Date('2024-02-04')}` as any,
+    publishedAt: new Date('2024-02-04').toISOString(),
     imageUrl:
       'https://developers.cyberagent.co.jp/blog/wp-content/uploads/2024/02/e2857132c0a68ad6f87379f38230e2f6.jpg',
   },
@@ -19,7 +19,7 @@ export const staticArticlesData: Article[] = [
       'この記事はCyberAgent Developers Advent Calendar 2023 7日目の記事です。こんにちは、AI事業本部の徳田(@tokkuu)です。OpenAIのC',
     source: 'blog',
     url: 'https://developers.cyberagent.co.jp/blog/archives/44386/',
-    publishedAt: `${new Date('2023-12-7')}` as any,
+    publishedAt: new Date('2023-12-07').toISOString(),
     imageUrl:
       'https://developers.cyberagent.co.jp/blog/wp-content/uploads/2023/12/Twitter-OGP-1.jpg',
   },

--- a/src/features/article/types/article.ts
+++ b/src/features/article/types/article.ts
@@ -3,6 +3,6 @@ export interface Article {
   bodySummary: string;
   source: 'zenn' | 'qiita' | 'blog';
   url: string;
-  publishedAt: Date;
+  publishedAt: string;
   imageUrl: string;
 }


### PR DESCRIPTION
publishedAt was typed as Date but each source emitted strings in
inconsistent formats (ISO from Zenn/Qiita, locale string from
static-data), so the lexicographic comparison produced incorrect order
when sources were combined.

Normalize publishedAt to an ISO string at the Article boundary and sort
by parsed timestamp difference. Add a unit test that verifies descending
order across multiple sources.

https://linear.app/tokku/issue/TOK-95