### PR TITLE
feat(article): aggregate note.com articles via RSS (TOK-94)

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -14,6 +14,7 @@ const config = {
   testEnvironment: 'jest-environment-jsdom',
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
   globalSetup: './spec/setupTest.ts',
+  setupFiles: ['<rootDir>/spec/jestPolyfills.ts'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/spec/jestPolyfills.ts
+++ b/spec/jestPolyfills.ts
@@ -1,0 +1,8 @@
+import { TextDecoder, TextEncoder } from 'util';
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder as unknown as typeof globalThis.TextEncoder;
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
+}

--- a/src/features/article/apis/article.spec.ts
+++ b/src/features/article/apis/article.spec.ts
@@ -6,11 +6,15 @@ jest.mock('./zenn', () => ({
 jest.mock('./qiita', () => ({
   fetchArticlesFromQiita: jest.fn(),
 }));
+jest.mock('./note', () => ({
+  fetchArticlesFromNote: jest.fn(),
+}));
 jest.mock('../data/static-data', () => ({
   staticArticlesData: [] as Article[],
 }));
 
 import { fetchArticles } from './article';
+import { fetchArticlesFromNote } from './note';
 import { fetchArticlesFromQiita } from './qiita';
 import { fetchArticlesFromZenn } from './zenn';
 import { staticArticlesData } from '../data/static-data';
@@ -20,6 +24,9 @@ const mockedZenn = fetchArticlesFromZenn as jest.MockedFunction<
 >;
 const mockedQiita = fetchArticlesFromQiita as jest.MockedFunction<
   typeof fetchArticlesFromQiita
+>;
+const mockedNote = fetchArticlesFromNote as jest.MockedFunction<
+  typeof fetchArticlesFromNote
 >;
 
 const buildArticle = (
@@ -58,6 +65,13 @@ describe('fetchArticles', () => {
         publishedAt: '2024-08-15T00:00:00.000Z',
       }),
     ]);
+    mockedNote.mockResolvedValue([
+      buildArticle({
+        title: 'note-mid',
+        source: 'note',
+        publishedAt: '2025-01-15T00:00:00.000Z',
+      }),
+    ]);
     (staticArticlesData as Article[]).push(
       buildArticle({
         title: 'blog-newest',
@@ -76,6 +90,7 @@ describe('fetchArticles', () => {
     expect(result.map((a) => a.title)).toEqual([
       'blog-newest',
       'zenn-new',
+      'note-mid',
       'qiita-mid',
       'zenn-old',
       'blog-oldest',
@@ -98,6 +113,7 @@ describe('fetchArticles', () => {
       }),
     ]);
     mockedQiita.mockResolvedValue([]);
+    mockedNote.mockResolvedValue([]);
 
     const result = await fetchArticles(2);
 

--- a/src/features/article/apis/article.ts
+++ b/src/features/article/apis/article.ts
@@ -1,13 +1,22 @@
 import { staticArticlesData } from '../data/static-data';
+import { fetchArticlesFromNote } from './note';
 import { fetchArticlesFromQiita } from './qiita';
 import { fetchArticlesFromZenn } from './zenn';
 
 export const fetchArticles = async (num?: number) => {
-  const zennArticles = await fetchArticlesFromZenn();
-  const qiitaArticles = await fetchArticlesFromQiita();
+  const [zennArticles, qiitaArticles, noteArticles] = await Promise.all([
+    fetchArticlesFromZenn(),
+    fetchArticlesFromQiita(),
+    fetchArticlesFromNote(),
+  ]);
   const staticArticles = staticArticlesData;
 
-  const articles = [...zennArticles, ...qiitaArticles, ...staticArticles];
+  const articles = [
+    ...zennArticles,
+    ...qiitaArticles,
+    ...noteArticles,
+    ...staticArticles,
+  ];
   const sortedArticles = articles.sort(
     (a, b) =>
       new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()

--- a/src/features/article/apis/note.spec.ts
+++ b/src/features/article/apis/note.spec.ts
@@ -1,0 +1,62 @@
+import { parseNoteRss } from './note';
+
+const sampleRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>tokku5552 のnote</title>
+    <link>https://note.com/tokku5552</link>
+    <description>tokku5552 のnote記事</description>
+    <item>
+      <title>はじめての記事</title>
+      <link>https://note.com/tokku5552/n/n1234567890ab</link>
+      <description><![CDATA[<p>これは note.com の記事の本文サマリです。</p><img src="https://example.com/inline.jpg" alt="inline" />]]></description>
+      <pubDate>Mon, 14 Apr 2025 12:00:00 GMT</pubDate>
+      <guid isPermaLink="true">https://note.com/tokku5552/n/n1234567890ab</guid>
+      <media:thumbnail url="https://assets.note.com/thumbnail/n1234567890ab.jpg" />
+    </item>
+    <item>
+      <title>サムネイル無しの記事</title>
+      <link>https://note.com/tokku5552/n/nffffffffffff</link>
+      <description><![CDATA[<p>サムネイル無し。</p>]]></description>
+      <pubDate>Sun, 13 Apr 2025 03:30:00 GMT</pubDate>
+      <guid isPermaLink="true">https://note.com/tokku5552/n/nffffffffffff</guid>
+    </item>
+  </channel>
+</rss>`;
+
+describe('parseNoteRss', () => {
+  test('item 要素から title / link / pubDate / thumbnail を抽出する', () => {
+    const items = parseNoteRss(sampleRss);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toEqual({
+      title: 'はじめての記事',
+      link: 'https://note.com/tokku5552/n/n1234567890ab',
+      description: expect.stringContaining('note.com の記事の本文サマリ'),
+      pubDate: 'Mon, 14 Apr 2025 12:00:00 GMT',
+      thumbnailUrl: 'https://assets.note.com/thumbnail/n1234567890ab.jpg',
+    });
+  });
+
+  test('media:thumbnail が無い場合は description 内の img を fallback として使う', () => {
+    const items = parseNoteRss(sampleRss);
+
+    expect(items[1].thumbnailUrl).toBe('');
+  });
+
+  test('description 内の img を fallback として使う', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>fallback</title>
+      <link>https://note.com/tokku5552/n/abcd</link>
+      <description><![CDATA[<p>x</p><img src="https://example.com/fallback.jpg" />]]></description>
+      <pubDate>Mon, 14 Apr 2025 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+    const [item] = parseNoteRss(xml);
+    expect(item.thumbnailUrl).toBe('https://example.com/fallback.jpg');
+  });
+});

--- a/src/features/article/apis/note.ts
+++ b/src/features/article/apis/note.ts
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { stripHtmlTags, truncateText } from '../../../libs/text';
+import { extractOgp, OgpData } from '../functions/extractOgp';
 import { Article } from '../types/article';
 import { NoteRssItem } from '../types/note';
 
@@ -8,7 +9,7 @@ const NOTE_RSS_URL = `https://note.com/${NOTE_USERNAME}/rss`;
 
 /**
  * note.com の記事を取得する
- * 公式RSSフィードから取得（認証不要、ビルド時に取得）
+ * 公式RSSフィードから記事一覧を取得し、各記事ページから OGP を抽出する
  * ref: https://note.com/{username}/rss
  */
 export const fetchArticlesFromNote = async (): Promise<Article[]> => {
@@ -26,13 +27,42 @@ export const fetchArticlesFromNote = async (): Promise<Article[]> => {
 
     const xml = await res.text();
     const items = parseNoteRss(xml);
-    return items.map(toArticleFromNote);
+
+    const result = await Promise.all(
+      items.map(async (item) => {
+        const ogp = await fetchOgpDataFromNote(item.link);
+        return { item, ogp };
+      })
+    );
+
+    return result.map(({ item, ogp }) => toArticleFromNote(item, ogp));
   } catch (error) {
     console.warn(
       'Failed to fetch note articles:',
       error instanceof Error ? error.message : error
     );
     return [];
+  }
+};
+
+const fetchOgpDataFromNote = async (url: string): Promise<OgpData> => {
+  try {
+    const encodedUri = encodeURI(url);
+    const res = await fetch(encodedUri, {
+      headers: {
+        'User-Agent': 'bot',
+      },
+    });
+    const html = await res.text();
+    const dom = new JSDOM(html);
+    const meta = dom.window.document.head.querySelectorAll('meta');
+    return extractOgp([...Array.from(meta)]);
+  } catch (error) {
+    console.warn(
+      `Failed to fetch OGP from note article ${url}:`,
+      error instanceof Error ? error.message : error
+    );
+    return {};
   }
 };
 
@@ -72,11 +102,11 @@ const extractFirstImgSrc = (html: string): string | null => {
   return match?.[1] ?? null;
 };
 
-const toArticleFromNote = (item: NoteRssItem): Article => ({
+const toArticleFromNote = (item: NoteRssItem, ogp: OgpData): Article => ({
   title: item.title,
   bodySummary: truncateText(stripHtmlTags(item.description), 100),
   source: 'note',
   url: item.link,
   publishedAt: new Date(item.pubDate).toISOString(),
-  imageUrl: item.thumbnailUrl,
+  imageUrl: ogp['og:image'] ?? item.thumbnailUrl,
 });

--- a/src/features/article/apis/note.ts
+++ b/src/features/article/apis/note.ts
@@ -1,0 +1,82 @@
+import { JSDOM } from 'jsdom';
+import { stripHtmlTags, truncateText } from '../../../libs/text';
+import { Article } from '../types/article';
+import { NoteRssItem } from '../types/note';
+
+const NOTE_USERNAME = 'tokku5552';
+const NOTE_RSS_URL = `https://note.com/${NOTE_USERNAME}/rss`;
+
+/**
+ * note.com の記事を取得する
+ * 公式RSSフィードから取得（認証不要、ビルド時に取得）
+ * ref: https://note.com/{username}/rss
+ */
+export const fetchArticlesFromNote = async (): Promise<Article[]> => {
+  try {
+    const res = await fetch(NOTE_RSS_URL, {
+      headers: {
+        'User-Agent': 'bot',
+      },
+    });
+
+    if (!res.ok) {
+      console.warn(`Failed to fetch note RSS: ${res.status} ${res.statusText}`);
+      return [];
+    }
+
+    const xml = await res.text();
+    const items = parseNoteRss(xml);
+    return items.map(toArticleFromNote);
+  } catch (error) {
+    console.warn(
+      'Failed to fetch note articles:',
+      error instanceof Error ? error.message : error
+    );
+    return [];
+  }
+};
+
+const MEDIA_NS = 'http://search.yahoo.com/mrss/';
+
+export const parseNoteRss = (xml: string): NoteRssItem[] => {
+  const dom = new JSDOM(xml, { contentType: 'text/xml' });
+  const items = Array.from(dom.window.document.getElementsByTagName('item'));
+
+  return items.map((item) => {
+    const getText = (tag: string) =>
+      item.getElementsByTagName(tag)[0]?.textContent?.trim() ?? '';
+
+    const description = getText('description');
+    const mediaThumb =
+      item.getElementsByTagNameNS(MEDIA_NS, 'thumbnail')[0] ??
+      item.getElementsByTagName('media:thumbnail')[0];
+    const enclosure = item.getElementsByTagName('enclosure')[0];
+    const thumbnailUrl =
+      mediaThumb?.getAttribute('url') ??
+      enclosure?.getAttribute('url') ??
+      extractFirstImgSrc(description) ??
+      '';
+
+    return {
+      title: getText('title'),
+      link: getText('link'),
+      description,
+      pubDate: getText('pubDate'),
+      thumbnailUrl,
+    };
+  });
+};
+
+const extractFirstImgSrc = (html: string): string | null => {
+  const match = html.match(/<img[^>]+src=["']([^"']+)["']/i);
+  return match?.[1] ?? null;
+};
+
+const toArticleFromNote = (item: NoteRssItem): Article => ({
+  title: item.title,
+  bodySummary: truncateText(stripHtmlTags(item.description), 100),
+  source: 'note',
+  url: item.link,
+  publishedAt: new Date(item.pubDate).toISOString(),
+  imageUrl: item.thumbnailUrl,
+});

--- a/src/features/article/components/ArticleItem.tsx
+++ b/src/features/article/components/ArticleItem.tsx
@@ -13,6 +13,7 @@ interface ArticleItemProps {
 const sourceLabel: Record<NonNullable<Article['source']>, string> = {
   zenn: 'Zenn',
   qiita: 'Qiita',
+  note: 'note',
   blog: 'Blog',
 };
 

--- a/src/features/article/types/article.ts
+++ b/src/features/article/types/article.ts
@@ -1,7 +1,7 @@
 export interface Article {
   title: string;
   bodySummary: string;
-  source: 'zenn' | 'qiita' | 'blog';
+  source: 'zenn' | 'qiita' | 'note' | 'blog';
   url: string;
   publishedAt: string;
   imageUrl: string;

--- a/src/features/article/types/note.ts
+++ b/src/features/article/types/note.ts
@@ -1,0 +1,7 @@
+export interface NoteRssItem {
+  title: string;
+  link: string;
+  description: string;
+  pubDate: string;
+  thumbnailUrl: string;
+}


### PR DESCRIPTION
note.com の公式RSS (https://note.com/{username}/rss) からビルド時に
記事を取得し、Zenn / Qiita / 静的データと統合して publishedAt 降順で表示する。
取得失敗時は警告ログのみで空配列を返し、ページビルドを止めない。

https://claude.ai/code/session_01RFfNUaAa31xdmtvBHck9G7