### PR TITLE
Remove company name from current role descriptions

### DIFF
--- a/src/features/home/components/HeroStrip.tsx
+++ b/src/features/home/components/HeroStrip.tsx
@@ -6,7 +6,7 @@ interface StripCell {
 }
 
 const cells: StripCell[] = [
-  { label: 'Currently', value: 'EM @ Mercari' },
+  { label: 'Currently', value: 'Engineering Manager' },
   { label: 'Discography', value: 'INKDOSE · 2026—' },
   { label: 'Podcast', value: 'エンジニアがもがくラジオ' },
   { label: 'Stack', value: 'TypeScript · Go · Flutter' },

--- a/src/features/home/components/TwilightHero.tsx
+++ b/src/features/home/components/TwilightHero.tsx
@@ -44,7 +44,7 @@ export default function TwilightHero() {
 
         <p className="mb-14 max-w-[640px] font-brand-sans text-[clamp(16px,1.25vw,18px)] font-normal leading-[1.55] text-brand-muted">
           <strong className="font-medium text-brand-fg">
-            Engineering Manager at Mercari.
+            Engineering Manager.
           </strong>{' '}
           Building teams and shipping product across TypeScript / Go / Flutter /
           AWS / GCP.


### PR DESCRIPTION
## 関連Issues

<!-- close #1-->

## 変更点

- HeroStrip.tsx: "Currently" の値を "EM @ Mercari" から "Engineering Manager" に変更
- TwilightHero.tsx: 自己紹介文を "Engineering Manager at Mercari." から "Engineering Manager." に変更

会社名を削除し、職務内容のみを表示するように更新しました。

## その他

- なし

https://claude.ai/code/session_01SojX5ycwbzrKkS8PtnTqWm