### PR TITLE
fix(article): silence jsdom "Could not parse CSS stylesheet" warnings

### DIFF
--- a/src/features/article/apis/createDom.ts
+++ b/src/features/article/apis/createDom.ts
@@ -1,0 +1,23 @@
+import { ConstructorOptions, JSDOM, VirtualConsole } from 'jsdom';
+
+/**
+ * JSDOM を生成する共通ヘルパ。
+ *
+ * 外部ページの `<style>` ブロックに jsdom の CSS パーサが対応しない構文
+ * (`color-mix()`, `@layer`, `@container` など) が含まれていると、
+ * jsdom が `virtualConsole` 経由で `Could not parse CSS stylesheet` を発火し
+ * デフォルトでは stderr を汚染する。機能には影響しないため、その jsdomError のみ
+ * 捨て、他の jsdomError は引き続き従来通り stderr に流す。
+ */
+export const createDom = (
+  html: string,
+  options?: ConstructorOptions
+): JSDOM => {
+  const virtualConsole = new VirtualConsole();
+  virtualConsole.on('jsdomError', (err) => {
+    if (err.message !== 'Could not parse CSS stylesheet') {
+      console.error(err);
+    }
+  });
+  return new JSDOM(html, { ...options, virtualConsole });
+};

--- a/src/features/article/apis/note.ts
+++ b/src/features/article/apis/note.ts
@@ -1,8 +1,8 @@
-import { JSDOM } from 'jsdom';
 import { stripHtmlTags, truncateText } from '../../../libs/text';
 import { extractOgp, OgpData } from '../functions/extractOgp';
 import { Article } from '../types/article';
 import { NoteRssItem } from '../types/note';
+import { createDom } from './createDom';
 
 const NOTE_USERNAME = 'tokku5552';
 const NOTE_RSS_URL = `https://note.com/${NOTE_USERNAME}/rss`;
@@ -54,7 +54,7 @@ const fetchOgpDataFromNote = async (url: string): Promise<OgpData> => {
       },
     });
     const html = await res.text();
-    const dom = new JSDOM(html);
+    const dom = createDom(html);
     const meta = dom.window.document.head.querySelectorAll('meta');
     return extractOgp([...Array.from(meta)]);
   } catch (error) {
@@ -69,7 +69,7 @@ const fetchOgpDataFromNote = async (url: string): Promise<OgpData> => {
 const MEDIA_NS = 'http://search.yahoo.com/mrss/';
 
 export const parseNoteRss = (xml: string): NoteRssItem[] => {
-  const dom = new JSDOM(xml, { contentType: 'text/xml' });
+  const dom = createDom(xml, { contentType: 'text/xml' });
   const items = Array.from(dom.window.document.getElementsByTagName('item'));
 
   return items.map((item) => {

--- a/src/features/article/apis/qiita.ts
+++ b/src/features/article/apis/qiita.ts
@@ -1,9 +1,9 @@
-import { JSDOM } from 'jsdom';
 import { config } from '../../../config/environment';
 import { stripHtmlTags, truncateText } from '../../../libs/text';
 import { extractOgp, OgpData } from '../functions/extractOgp';
 import { Article } from '../types/article';
 import { QiitaArticle, QiitaArticleResponse } from '../types/qiita';
+import { createDom } from './createDom';
 
 /**
  * Qiitaの記事を取得する
@@ -61,7 +61,7 @@ const fetchOgpDataFromQiita = async (url: string): Promise<OgpData> => {
     },
   });
   const html = await res.text();
-  const dom = new JSDOM(html);
+  const dom = createDom(html);
 
   // metaデータを取得し、ogpの各データを抽出
   const meta = dom.window.document.head.querySelectorAll('meta');

--- a/src/features/article/apis/zenn.ts
+++ b/src/features/article/apis/zenn.ts
@@ -1,8 +1,8 @@
-import { JSDOM } from 'jsdom';
 import { stripHtmlTags, truncateText } from '../../../libs/text';
 import { extractOgp, OgpData } from '../functions/extractOgp';
 import { Article } from '../types/article';
 import { ZennArticle, ZennArticleResponse } from '../types/zenn';
+import { createDom } from './createDom';
 
 export const fetchArticlesFromZenn = async (): Promise<Article[]> => {
   try {
@@ -51,7 +51,7 @@ const fetchOgpDataFromZenn = async (
     },
   });
   const html = await res.text();
-  const dom = new JSDOM(html);
+  const dom = createDom(html);
 
   // metaデータを取得し、ogpの各データを抽出
   const meta = dom.window.document.head.querySelectorAll('meta');


### PR DESCRIPTION
Wrap each JSDOM construction in a shared createDom helper that installs a
custom VirtualConsole. The handler drops only the "Could not parse CSS
stylesheet" jsdomError emitted when fetched pages use modern CSS syntax
jsdom doesn't support (color-mix(), @layer, @container), while letting
every other jsdomError through to stderr.